### PR TITLE
Add conversation message saving

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -31,6 +31,9 @@ jobs:
   tests:
     runs-on: ubuntu-latest
 
+    env:
+      TEST_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+
     services:
       postgres:
         image: postgres:16
@@ -41,7 +44,7 @@ jobs:
           POSTGRES_PASSWORD: postgres
           POSTGRES_DB: postgres
         options: >-
-          --health-cmd="pg_isready -U test -d postgres"
+          --health-cmd="pg_isready -U postgres -d postgres"
           --health-interval=10s
           --health-timeout=5s
           --health-retries=5
@@ -72,10 +75,16 @@ jobs:
         run: |
           python -m pip install --upgrade pip
           pip install -r apps/lv-pyapi/requirements.txt
+      
+      - name: Run test database migrations
+        run: npx prisma migrate deploy
+        env:
+          DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 
       - name: Run lv-pyapi tests
         env:
           GEMINI_API_KEY: ${{ secrets.GEMINI_API_KEY }}
           PYTHONPATH: ${{ github.workspace }}/apps/lv-pyapi:${{ github.workspace }}/packages/python-utils/src
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+          TEST_DATABASE_URL: ${{ env.TEST_DATABASE_URL }}
         run: pytest apps/lv-pyapi/tests --asyncio-mode=auto

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -77,7 +77,7 @@ jobs:
           pip install -r apps/lv-pyapi/requirements.txt
       
       - name: Run test database migrations
-        run: npx prisma migrate deploy
+        run: npx prisma migrate deploy --schema ./packages/database/prisma/schema/schema.prisma
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -36,7 +36,7 @@ jobs:
 
     services:
       postgres:
-        image: postgres:16
+        image: pgvector/pgvector:pg16
         ports:
           - 5432:5432
         env:

--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -80,6 +80,7 @@ jobs:
         run: npx prisma migrate deploy --schema ./packages/database/prisma/schema/schema.prisma
         env:
           DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
+          DIRECT_DATABASE_URL: postgresql://postgres:postgres@localhost:5432/postgres
 
       - name: Run lv-pyapi tests
         env:

--- a/apps/lv-pyapi/main.py
+++ b/apps/lv-pyapi/main.py
@@ -12,6 +12,7 @@ from database import get_db
 from python_utils.sqlalchemy_models import User
 from message_save import save_message
 from python_utils.sqlalchemy_models import User, MessageSender
+from fastapi.responses import JSONResponse
 
 
 # Load environment variables

--- a/apps/lv-pyapi/message_save.py
+++ b/apps/lv-pyapi/message_save.py
@@ -1,0 +1,13 @@
+from sqlalchemy.orm import Session
+from python_utils.sqlalchemy_models import ConversationMessage, MessageSender
+
+def save_message(db: Session, user_id: str, sender: MessageSender, content: str):
+    message = ConversationMessage(
+        userId=user_id,
+        sender=sender,
+        content=content,
+    )
+    db.add(message)
+    db.commit()
+    db.refresh(message)
+    return message

--- a/apps/lv-pyapi/tests/conftest.py
+++ b/apps/lv-pyapi/tests/conftest.py
@@ -1,0 +1,9 @@
+import sys
+import os
+
+#this is needed to import the python_utils models into the tests
+ROOT = os.path.abspath(os.path.join(os.path.dirname(__file__), "../../.."))
+UTILS_PATH = os.path.join(ROOT, "packages/python-utils/src")
+
+if UTILS_PATH not in sys.path:
+    sys.path.insert(0, UTILS_PATH)

--- a/apps/lv-pyapi/tests/test_gemini.py
+++ b/apps/lv-pyapi/tests/test_gemini.py
@@ -5,7 +5,7 @@ client = TestClient(app)
 
 # Test Gemini endpoint with real API call
 def test_gemini():
-  response = client.post("/api/gemini", json={"prompt": "say only 'hello'"})
+  response = client.post("/api/gemini", json={"prompt": "say only 'hello'", "userId": "123"})
   data = response.json()
   assert response.status_code == 200
   assert data["status"] == 200

--- a/apps/lv-pyapi/tests/test_gemini.py
+++ b/apps/lv-pyapi/tests/test_gemini.py
@@ -5,7 +5,7 @@ client = TestClient(app)
 
 # Test Gemini endpoint with real API call
 def test_gemini():
-  response = client.post("/api/gemini", json={"prompt": "say only 'hello'", "userId": "123"})
+  response = client.post("/api/gemini", json={"prompt": "say only 'hello'"})
   data = response.json()
   assert response.status_code == 200
   assert data["status"] == 200

--- a/apps/lv-pyapi/tests/unit/test_message_saving.py
+++ b/apps/lv-pyapi/tests/unit/test_message_saving.py
@@ -1,0 +1,70 @@
+import os
+import pytest
+import uuid
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from message_save import save_message
+from python_utils.sqlalchemy_models import Base, ConversationMessage, MessageSender, User
+
+raw_url = os.getenv("TEST_DATABASE_URL")
+assert raw_url, "TEST_DATABASE_URL is not set"
+TEST_DATABASE_URL = raw_url
+
+
+#this is a fixture that creates a database session for the tests
+@pytest.fixture
+def db_session():
+    engine = create_engine(TEST_DATABASE_URL)
+
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+#this is a test that saves a user message to the database
+def test_save_user_message(db_session: Session):
+    user_id = str(uuid.uuid4())
+    sender = MessageSender.USER
+    content = "Hello world"
+
+
+    test_user = User(id=user_id, email=f"{uuid.uuid4()}@example.com", name="Test User", createdAt=datetime.now(), updatedAt=datetime.now())
+    db_session.add(test_user)
+    db_session.commit()
+
+    msg = save_message(db_session, user_id, sender, content)
+    assert msg.userId == test_user.id
+    assert msg.sender == sender
+    assert msg.content == content
+    assert msg.messageId is not None
+    assert msg.createdAt is not None
+
+    stored = db_session.query(ConversationMessage).filter_by(messageId=msg.messageId).first()
+    assert stored is not None
+    assert stored.sender == sender
+    assert stored.content == content
+
+#this is a test that saves an AI message to the database
+def test_save_ai_message(db_session: Session):
+    user_id = str(uuid.uuid4())
+    sender = MessageSender.AI
+    content = "Hello world"
+
+    test_user = User(id=user_id, email=f"{uuid.uuid4()}@example.com", name="Test User", createdAt=datetime.now(), updatedAt=datetime.now())
+    db_session.add(test_user)
+    db_session.commit()
+
+    msg = save_message(db_session, user_id, sender, content)
+    assert msg.userId == test_user.id
+    assert msg.sender == sender
+    assert msg.content == content
+    assert msg.messageId is not None
+    assert msg.createdAt is not None
+
+    stored = db_session.query(ConversationMessage).filter_by(messageId=msg.messageId).first()
+    assert stored is not None
+    assert stored.sender == sender

--- a/apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx
@@ -2,10 +2,15 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
 import InterviewPage from '../../app/interview/page';
+import { getGeminiResponse } from '@/lib/services/pyapi';
 
 // Mock next-auth/react
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
+}));
+
+jest.mock('@/lib/services/pyapi', () => ({
+  getGeminiResponse: jest.fn(),
 }));
 
 // Mock next/navigation
@@ -57,14 +62,9 @@ describe('InterviewPage - Chat Interaction', () => {
     expect(textarea).toHaveValue('Yes, I am very dedicated.');
 
     // Mock the AI's response
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 'ai-response-1',
-        role: 'ai',
-        content: 'That is great to hear!',
-        timestamp: new Date(),
-      }),
+    (getGeminiResponse as jest.Mock).mockResolvedValueOnce({
+      message: 'That is great to hear!',
+      status: 200,
     });
 
     // User clicks the "Send" button
@@ -104,14 +104,9 @@ describe('InterviewPage - Chat Interaction', () => {
     fireEvent.change(textarea, { target: { value: 'Test Enter' } });
 
     // Mock AI response before pressing Enter
-    (fetch as jest.Mock).mockResolvedValueOnce({
-      ok: true,
-      json: async () => ({
-        id: 'ai-response-enter',
-        role: 'ai',
-        content: 'Received via Enter',
-        timestamp: new Date(),
-      }),
+    (getGeminiResponse as jest.Mock).mockResolvedValueOnce({
+      message: 'Received via Enter',
+      status: 200,
     });
 
     // Press Enter to submit

--- a/apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx
@@ -2,14 +2,14 @@ import '@testing-library/jest-dom';
 import { fireEvent, render, screen, waitFor } from '@testing-library/react';
 import { useSession } from 'next-auth/react';
 import InterviewPage from '../../app/interview/page';
-import { getGeminiResponse } from '@/lib/services/pyapi';
+import { getGeminiResponse } from '../../lib/services/pyapi';
 
 // Mock next-auth/react
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
 }));
 
-jest.mock('@/lib/services/pyapi', () => ({
+jest.mock('../../lib/services/pyapi', () => ({
   getGeminiResponse: jest.fn(),
 }));
 

--- a/apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx
@@ -40,7 +40,7 @@ describe('InterviewPage - Chat Interaction', () => {
 
   it('should allow a user to send a message and receive a response', async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { name: 'Test User' } },
+      data: { user: { id: 'test-user-id', name: 'Test User' } },
       status: 'authenticated',
     });
     render(<InterviewPage />);
@@ -93,7 +93,7 @@ describe('InterviewPage - Chat Interaction', () => {
 
   it('submits the message when Enter is pressed', async () => {
     mockUseSession.mockReturnValue({
-      data: { user: { name: 'Enter Tester' } },
+      data: { user: { id: 'enter-tester-id', name: 'Enter Tester' } },
       status: 'authenticated',
     });
     render(<InterviewPage />);

--- a/apps/lv-web/src/lib/services/pyapi.ts
+++ b/apps/lv-web/src/lib/services/pyapi.ts
@@ -40,6 +40,7 @@ export async function getUser(userId: string): Promise<PyAPIUser> {
 }
 
 export async function getGeminiResponse(
+  userId: string,
   userMessage: string
 ): Promise<{ message: string; status: number }> {
   const response = await fetch(`${getBaseUrl()}/api/gemini`, {
@@ -47,8 +48,11 @@ export async function getGeminiResponse(
     headers: {
       'Content-Type': 'application/json',
     },
-    body: JSON.stringify({ prompt: userMessage }),
+    body: JSON.stringify({ userId: userId, prompt: userMessage }),
   });
+  if (!response.ok) {
+    throw new Error(`Failed to get AI response: ${response.statusText}`);
+  }
 
   return response.json();
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -138,6 +138,62 @@ services:
     volumes:
       - postgres_data:/var/lib/postgresql/data
       # - we can add create_db.sql
+  
+  test-postgres:
+    profiles: ['tests']
+    container_name: lv-test-db
+    image: pgvector/pgvector:pg16
+    environment:
+      - POSTGRES_USER=postgres
+      - POSTGRES_PASSWORD=postgres
+      - POSTGRES_DB=test_db
+    ports:
+      - '5433:5432'
+    volumes:
+      - postgres_test_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U postgres -d test_db"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
+  test-migrate:
+    profiles: ['tests']
+    container_name: lv-test-db-migrate
+    build:
+      context: .
+      dockerfile: ./packages/database/Dockerfile.web
+    depends_on:
+      - test-postgres
+    environment:
+      - DATABASE_URL=postgresql://postgres:postgres@test-postgres:5432/test_db
+      - DIRECT_DATABASE_URL=postgresql://postgres:postgres@test-postgres:5432/test_db
+    command: sh -c "
+      echo 'Waiting for test database...' &&
+      until pg_isready -h test-postgres -U postgres -d test_db; do sleep 1; done &&
+      cd packages/database &&
+      npx prisma migrate deploy
+      "
+    volumes:
+      - .:/app
+      - /app/node_modules
+  
+  test-runner:
+    profiles: ['tests']
+    container_name: lv-test-runner
+    build:
+      context: .
+      dockerfile: ./apps/lv-pyapi/Dockerfile
+    depends_on:
+      - test-migrate
+    environment:
+      - TEST_DATABASE_URL=postgresql://postgres:postgres@test-postgres:5432/test_db
+      - PYTHONPATH=/app/apps/lv-pyapi:/app/packages/python-utils/src
+    volumes:
+      - .:/app
+    command: pytest tests --asyncio-mode=auto
+    
+    
 volumes:
   postgres_data:
+  postgres_test_data:

--- a/packages/python-utils/src/python_utils/sqlalchemy_models.py
+++ b/packages/python-utils/src/python_utils/sqlalchemy_models.py
@@ -107,7 +107,8 @@ class User(Base):
     account: Mapped[List["Account"]] = relationship("Account", back_populates="user")
     session: Mapped[List["Session"]] = relationship("Session", back_populates="user")
     authenticator: Mapped[List["Authenticator"]] = relationship("Authenticator", back_populates="user")
-
+    conversation_messages: Mapped[List["ConversationMessage"]] = relationship("ConversationMessage", back_populates="user")
+    
 class Vector(TypeDecorator):
     """Custom type for PostgreSQL vector type"""
     impl = String
@@ -149,3 +150,19 @@ class _prisma_migrations(Base):
     started_at: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
     applied_steps_count: Mapped[int] = mapped_column(Integer, nullable=False)
 
+class MessageSender(enum.Enum):
+    USER = "USER"
+    AI = "AI"
+
+class ConversationMessage(Base):
+    __tablename__ = "ConversationMessage"
+    __table_args__ = {'schema': 'public'}
+
+    messageId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
+    userId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.User.id"), nullable=False)
+    sender: Mapped[MessageSender] = mapped_column(ENUM(MessageSender, name="MessageSender"), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    createdAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="conversation_messages")


### PR DESCRIPTION
### Overview:
This PR implements issue #67 :  saving conversation messages (actual user + AI) to the database. The changes span Backend, Database, Frontend, unit tests, and CI/Docker

### Key Files & What they do?
**Backend:**
- `apps/lv-pyapi/message_save.py`
  - Contains save_message(db, user_id, sender, content)
  - Creates and stores ConversationMessage rows into the DB
- `apps/lv-pyapi/main.py`
  - Handles /api/gemini endpoint.
  - Saves the user message before sending request to Gemini.
  - Saves the AI message right after receiving the response.
- `python_utils/sqlalchemy_models.py`
  - Defines ConversationMessage SQLAlchemy model

**Frontend:**
- `app/interview/page.tsx`
  - Sends user message to backend.
  - Receives AI message from backend.
  - Displays both messages in UI.
- `lib/services/pypapi.ts`
  - Wrapper around calling /api/gemini

**Testing:**
- `apps/lv-pyapi/tests/unit/test_message_saving.py`
  - Unit tests verifying DB insert logic for user and AI messages
- `apps/lv-web/src/__tests__/unit/interview-page.chat.test.tsx` 
  - verifies the full chat interaction on the frontend by mocking the session, user message, backend response, and ensuring both user + AI messages appear correctly in the UI.
  
**CI / Docker:**
- `.github/workflows/CI.yml`
  - Adds Postgres test service.
  - Runs Prisma migrations for the test DB.
  - Runs pytest.
- `docker-compose.yml`
  - Provides test Postgres instance.
  - Migration + test runner containers.


### Functional testing:
1. Start the local with:
`docker compose --profile lv-web up -d --build`
2. Open the chat UI and send some messages to the chat
3. Connect to the local DB with:
`sudo docker exec -it $(docker ps -q --filter name=lv-db) psql -U postgres`
4. List tables with `\dt`
You should see a table called "ConversationMessage" among others
5. View the last 10 messages in descending creation order:
```
SELECT *
FROM "ConversationMessage"
ORDER BY "createdAt" DESC
LIMIT 10;
```
6. Check if both user and AI messages appear

### Unit testing (run all in the root folder):
1. Remove old test DB (if any)
`docker compose --profile tests down -v`
3. Start the Postgres test DB
`docker compose --profile tests up -d test-postgres`
5. Run migrations
`docker compose --profile tests run --rm test-migrate`
7. Finally, run the unit tests
`docker compose --profile tests run --rm test-runner`

### Important concepts & choices explained:
- What is a `database session` (that is used almost everywhere)?
  - A temporary workspace where your request safely reads and saves data until everything is done. So, all changes either succeed together or fail together. No 'half-saved' states.
- Why do we need `conftest.py`?
  - Because our tests run in a different directory, so Python couldn't automatically find python-utils or the SQLAlchemy models...and moving a whole directory sounded too risky. So, conftest.py fixes the import path once, so every test can access those modules without messy relative imports.