### PR TITLE
Add Learnings to the Message System

### DIFF
--- a/apps/lv-pyapi/tests/unit/test_learning_model.py
+++ b/apps/lv-pyapi/tests/unit/test_learning_model.py
@@ -6,7 +6,7 @@ from sqlalchemy import create_engine
 from sqlalchemy.orm import sessionmaker, Session
 
 from message_save import save_message
-from python_utils.sqlalchemy_models import Base, ConversationMessage, MessageSender, User, Learning
+from python_utils.sqlalchemy_models import Base, ConversationMessage, MessageSender, User, Learning, _ConversationMessageToLearning
 
 raw_url = os.getenv("TEST_DATABASE_URL")
 assert raw_url, "TEST_DATABASE_URL is not set"
@@ -45,11 +45,16 @@ def test_create_learning_with_messages(db_session: Session):
     msg2 = save_message(db_session, user_id, sender, msg2_content)
 
     summary_text = "User likes cats."
+
+    # Associating messages with learning
+    assoc1 = _ConversationMessageToLearning(conversationMessage=msg1)
+    assoc2 = _ConversationMessageToLearning(conversationMessage=msg2)
+
     test_learning = Learning(
         userId=user_id,
         summary=summary_text,
         updatedAt=datetime.now(),
-        messages=[msg1, msg2]
+        _ConversationMessageToLearning=[assoc1, assoc2]
     )
 
     db_session.add(test_learning)
@@ -59,9 +64,9 @@ def test_create_learning_with_messages(db_session: Session):
     stored = db_session.query(Learning).filter_by(id=test_learning.id).first()
     assert stored is not None
     assert stored.summary == summary_text
-    assert len(stored.messages) == 2
+    assert len(stored._ConversationMessageToLearning) == 2
     
-    message_contents = [m.content for m in stored.messages]
+    message_contents = [assoc.conversationMessage.content for assoc in stored._ConversationMessageToLearning]
     assert msg1_content in message_contents
     assert msg2_content in message_contents
     

--- a/apps/lv-pyapi/tests/unit/test_learning_model.py
+++ b/apps/lv-pyapi/tests/unit/test_learning_model.py
@@ -1,0 +1,70 @@
+import os
+import pytest
+import uuid
+from datetime import datetime
+from sqlalchemy import create_engine
+from sqlalchemy.orm import sessionmaker, Session
+
+from message_save import save_message
+from python_utils.sqlalchemy_models import Base, ConversationMessage, MessageSender, User, Learning
+
+raw_url = os.getenv("TEST_DATABASE_URL")
+assert raw_url, "TEST_DATABASE_URL is not set"
+TEST_DATABASE_URL = raw_url
+
+#this is a fixture that creates a database session for the tests
+@pytest.fixture
+def db_session():
+    engine = create_engine(TEST_DATABASE_URL)
+
+    SessionLocal = sessionmaker(bind=engine)
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+
+def test_create_learning_with_messages(db_session: Session):
+    user_id = str(uuid.uuid4())
+    sender = MessageSender.USER
+
+    test_user = User(
+        id=user_id, 
+        email=f"{uuid.uuid4()}@example.com", 
+        name="Test User", 
+        createdAt=datetime.now(), 
+        updatedAt=datetime.now()
+    )
+    db_session.add(test_user)
+    db_session.commit()
+
+    msg1Content = "I like cats."
+    msg1 = save_message(db_session, user_id, sender, msg1Content)
+
+    msg2Content = "Cats are great pets!"
+    msg2 = save_message(db_session, user_id, sender, msg2Content)
+
+    db_session.add(msg1)
+    db_session.add(msg2)
+
+    summary_text = "User likes cats."
+    test_learning = Learning(
+        userId=user_id,
+        summary=summary_text,
+        updatedAt=datetime.now(),
+        messages=[msg1, msg2]
+    )
+
+    db_session.add(test_learning)
+    db_session.commit()
+    db_session.refresh(test_learning)
+
+    stored = db_session.query(Learning).filter_by(id=test_learning.id).first()
+    assert stored is not None
+    assert stored.summary == summary_text
+    assert len(stored.messages) == 2
+    
+    message_contents = [m.content for m in stored.messages]
+    assert msg1Content in message_contents
+    assert msg2Content in message_contents
+    

--- a/apps/lv-pyapi/tests/unit/test_learning_model.py
+++ b/apps/lv-pyapi/tests/unit/test_learning_model.py
@@ -43,8 +43,6 @@ def test_create_learning_with_messages(db_session: Session):
 
     msg2_content = "Cats are great pets!"
     msg2 = save_message(db_session, user_id, sender, msg2_content)
-    db_session.add(msg1)
-    db_session.add(msg2)
 
     summary_text = "User likes cats."
     test_learning = Learning(

--- a/apps/lv-pyapi/tests/unit/test_learning_model.py
+++ b/apps/lv-pyapi/tests/unit/test_learning_model.py
@@ -38,12 +38,11 @@ def test_create_learning_with_messages(db_session: Session):
     db_session.add(test_user)
     db_session.commit()
 
-    msg1Content = "I like cats."
-    msg1 = save_message(db_session, user_id, sender, msg1Content)
+    msg1_content = "I like cats."
+    msg1 = save_message(db_session, user_id, sender, msg1_content)
 
-    msg2Content = "Cats are great pets!"
-    msg2 = save_message(db_session, user_id, sender, msg2Content)
-
+    msg2_content = "Cats are great pets!"
+    msg2 = save_message(db_session, user_id, sender, msg2_content)
     db_session.add(msg1)
     db_session.add(msg2)
 
@@ -65,6 +64,6 @@ def test_create_learning_with_messages(db_session: Session):
     assert len(stored.messages) == 2
     
     message_contents = [m.content for m in stored.messages]
-    assert msg1Content in message_contents
-    assert msg2Content in message_contents
+    assert msg1_content in message_contents
+    assert msg2_content in message_contents
     

--- a/apps/lv-pyapi/tests/unit/test_message_saving.py
+++ b/apps/lv-pyapi/tests/unit/test_message_saving.py
@@ -31,8 +31,14 @@ def test_save_user_message(db_session: Session):
     sender = MessageSender.USER
     content = "Hello world"
 
+    test_user = User(
+        id=user_id, 
+        email=f"{uuid.uuid4()}@example.com", 
+        name="Test User", 
+        createdAt=datetime.now(), 
+        updatedAt=datetime.now()
+    )
 
-    test_user = User(id=user_id, email=f"{uuid.uuid4()}@example.com", name="Test User", createdAt=datetime.now(), updatedAt=datetime.now())
     db_session.add(test_user)
     db_session.commit()
 
@@ -54,7 +60,14 @@ def test_save_ai_message(db_session: Session):
     sender = MessageSender.AI
     content = "Hello world"
 
-    test_user = User(id=user_id, email=f"{uuid.uuid4()}@example.com", name="Test User", createdAt=datetime.now(), updatedAt=datetime.now())
+    test_user = User(
+        id=user_id, 
+        email=f"{uuid.uuid4()}@example.com", 
+        name="Test User", 
+        createdAt=datetime.now(), 
+        updatedAt=datetime.now()
+    )
+
     db_session.add(test_user)
     db_session.commit()
 

--- a/packages/database/prisma/schema/migrations/20251202144856_learning_schema/migration.sql
+++ b/packages/database/prisma/schema/migrations/20251202144856_learning_schema/migration.sql
@@ -1,0 +1,33 @@
+-- CreateTable
+CREATE TABLE "Learning" (
+    "id" UUID NOT NULL DEFAULT gen_random_uuid(),
+    "userId" UUID NOT NULL,
+    "summary" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "Learning_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateTable
+CREATE TABLE "_ConversationMessageToLearning" (
+    "A" UUID NOT NULL,
+    "B" UUID NOT NULL,
+
+    CONSTRAINT "_ConversationMessageToLearning_AB_pkey" PRIMARY KEY ("A","B")
+);
+
+-- CreateIndex
+CREATE INDEX "Learning_userId_idx" ON "Learning"("userId");
+
+-- CreateIndex
+CREATE INDEX "_ConversationMessageToLearning_B_index" ON "_ConversationMessageToLearning"("B");
+
+-- AddForeignKey
+ALTER TABLE "Learning" ADD CONSTRAINT "Learning_userId_fkey" FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ConversationMessageToLearning" ADD CONSTRAINT "_ConversationMessageToLearning_A_fkey" FOREIGN KEY ("A") REFERENCES "ConversationMessage"("messageId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "_ConversationMessageToLearning" ADD CONSTRAINT "_ConversationMessageToLearning_B_fkey" FOREIGN KEY ("B") REFERENCES "Learning"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/packages/database/prisma/schema/schema.prisma
+++ b/packages/database/prisma/schema/schema.prisma
@@ -2,7 +2,7 @@
 // add migrations to the schema to avoid the error:
 generator client {
   provider        = "prisma-client-js"
-  output = "../generated/client"
+  output          = "../generated/client"
   previewFeatures = ["postgresqlExtensions"]
 }
 

--- a/packages/database/prisma/schema/shared.prisma
+++ b/packages/database/prisma/schema/shared.prisma
@@ -22,6 +22,7 @@ model User {
   sessions                      Session[]
   Authenticator                 Authenticator[]
   messages                      ConversationMessage[]
+  learnings                     Learning[]
 
   @@index([id])
   @@index([email])
@@ -93,7 +94,20 @@ model ConversationMessage {
   content     String
   createdAt   DateTime      @default(now())
   user        User          @relation(fields: [userId], references: [id])
+  learnings   Learning[]
 
+  @@index([userId])
+}
+
+model Learning {
+  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String   @db.Uuid
+  summary   String
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+  user     User      @relation(fields: [userId], references: [id])
+  messages ConversationMessage[]
+  
   @@index([userId])
 }
 

--- a/packages/database/prisma/schema/shared.prisma
+++ b/packages/database/prisma/schema/shared.prisma
@@ -3,33 +3,33 @@
 
 model User {
   // Metadata
-  id                            String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  createdAt                     DateTime      @default(now())
-  updatedAt                     DateTime      @updatedAt
-  emailVerified                 DateTime?
+  id            String    @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  createdAt     DateTime  @default(now())
+  updatedAt     DateTime  @updatedAt
+  emailVerified DateTime?
 
   // Basic profile attributes
-  name                          String?
-  first_name                    String?
-  last_name                     String?
-  email                         String        @unique
-  image                         String?
-  phone                         String?
-  bio                           String?
+  name       String?
+  first_name String?
+  last_name  String?
+  email      String  @unique
+  image      String?
+  phone      String?
+  bio        String?
 
   // OAuth relations
-  accounts                      Account[]
-  sessions                      Session[]
-  Authenticator                 Authenticator[]
-  messages                      ConversationMessage[]
-  learnings                     Learning[]
+  accounts      Account[]
+  sessions      Session[]
+  Authenticator Authenticator[]
+  messages      ConversationMessage[]
+  learnings     Learning[]
 
   @@index([id])
   @@index([email])
 }
 
 model Account {
-  userId            String  @db.Uuid
+  userId            String   @db.Uuid
   type              String
   provider          String
   providerAccountId String
@@ -88,30 +88,30 @@ model Authenticator {
 }
 
 model ConversationMessage {
-  messageId   String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId      String        @db.Uuid
-  sender      MessageSender
-  content     String
-  createdAt   DateTime      @default(now())
-  user        User          @relation(fields: [userId], references: [id])
-  learnings   Learning[]
+  messageId String        @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String        @db.Uuid
+  sender    MessageSender
+  content   String
+  createdAt DateTime      @default(now())
+  user      User          @relation(fields: [userId], references: [id])
+  learnings Learning[]
 
   @@index([userId])
 }
 
 model Learning {
-  id        String   @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
-  userId    String   @db.Uuid
+  id        String                @id @default(dbgenerated("gen_random_uuid()")) @db.Uuid
+  userId    String                @db.Uuid
   summary   String
-  createdAt DateTime @default(now())
-  updatedAt DateTime @updatedAt
-  user     User      @relation(fields: [userId], references: [id])
-  messages ConversationMessage[]
-  
+  createdAt DateTime              @default(now())
+  updatedAt DateTime              @updatedAt
+  user      User                  @relation(fields: [userId], references: [id])
+  messages  ConversationMessage[]
+
   @@index([userId])
 }
 
 enum MessageSender {
-  USER 
+  USER
   AI
 }

--- a/packages/python-utils/src/python_utils/sqlalchemy_models.py
+++ b/packages/python-utils/src/python_utils/sqlalchemy_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, DateTime, Boolean, Integer, BigInteger, ForeignKey, ForeignKeyConstraint, Table, ARRAY, Text, Float, Enum, text, func, event
+from sqlalchemy import String, DateTime, Boolean, Integer, BigInteger, ForeignKey, ForeignKeyConstraint, Table, ARRAY, Text, Float, Enum, text, func, event, Column
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID, TIMESTAMP, DOUBLE_PRECISION, ENUM
 from sqlalchemy.orm import DeclarativeBase, relationship, Mapped, mapped_column, Mapper
 from sqlalchemy.types import TypeDecorator
@@ -108,6 +108,7 @@ class User(Base):
     session: Mapped[List["Session"]] = relationship("Session", back_populates="user")
     authenticator: Mapped[List["Authenticator"]] = relationship("Authenticator", back_populates="user")
     conversation_messages: Mapped[List["ConversationMessage"]] = relationship("ConversationMessage", back_populates="user")
+    learnings: Mapped[List["Learning"]] = relationship("Learning", back_populates="user")
     
 class Vector(TypeDecorator):
     """Custom type for PostgreSQL vector type"""
@@ -154,6 +155,14 @@ class MessageSender(enum.Enum):
     USER = "USER"
     AI = "AI"
 
+# Relationship between ConversationMessage and Learning
+t_ConversationMessageToLearning = Table(
+    '_ConversationMessageToLearning', Base.metadata,
+    Column('A', PostgresUUID(as_uuid=True), ForeignKey('public.ConversationMessage.messageId'), primary_key=True, nullable=False),
+    Column('B', PostgresUUID(as_uuid=True), ForeignKey('public.Learning.id'), primary_key=True, nullable=False),
+    schema='public'
+)
+
 class ConversationMessage(Base):
     __tablename__ = "ConversationMessage"
     __table_args__ = {'schema': 'public'}
@@ -166,3 +175,18 @@ class ConversationMessage(Base):
 
     # Relationships
     user: Mapped["User"] = relationship("User", back_populates="conversation_messages")
+    learnings: Mapped[List["Learning"]] = relationship("Learning", secondary=t_ConversationMessageToLearning, back_populates="messages")
+
+class Learning(Base):
+    __tablename__ = "Learning"
+    __table_args__ = {'schema': 'public'}
+
+    id: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
+    userId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.User.id"), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    createdAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
+    updatedAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now())
+
+    # Relationships
+    user: Mapped["User"] = relationship("User", back_populates="learnings")
+    messages: Mapped[List["ConversationMessage"]] = relationship("ConversationMessage", secondary=t_ConversationMessageToLearning, back_populates="learnings")

--- a/packages/python-utils/src/python_utils/sqlalchemy_models.py
+++ b/packages/python-utils/src/python_utils/sqlalchemy_models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import String, DateTime, Boolean, Integer, BigInteger, ForeignKey, ForeignKeyConstraint, Table, ARRAY, Text, Float, Enum, text, func, event, Column
+from sqlalchemy import String, DateTime, Boolean, Integer, BigInteger, ForeignKey, ForeignKeyConstraint, Table, ARRAY, Text, Float, Enum, text, func, event
 from sqlalchemy.dialects.postgresql import UUID as PostgresUUID, TIMESTAMP, DOUBLE_PRECISION, ENUM
 from sqlalchemy.orm import DeclarativeBase, relationship, Mapped, mapped_column, Mapper
 from sqlalchemy.types import TypeDecorator
@@ -6,6 +6,13 @@ from uuid import UUID
 from typing import Optional, List, Any, Sequence
 from datetime import datetime
 import enum
+
+# Enum Classes
+class MessageSender(enum.Enum):
+    """Enum type for MessageSender"""
+    USER = 'USER'
+    AI = 'AI'
+
 
 
 # Base Class
@@ -71,6 +78,36 @@ class Authenticator(Base):
     user: Mapped["User"] = relationship("User", back_populates="authenticator", uselist=False)
 
 
+class ConversationMessage(Base):
+    __tablename__ = "ConversationMessage"
+    __table_args__ = {'schema': 'public'}
+
+    messageId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
+    userId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.User.id"), nullable=False)
+    sender: Mapped[MessageSender] = mapped_column(Enum(MessageSender), nullable=False)
+    content: Mapped[str] = mapped_column(Text, nullable=False)
+    createdAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
+
+    # Relationships
+    _ConversationMessageToLearning: Mapped[List["_ConversationMessageToLearning"]] = relationship("_ConversationMessageToLearning", back_populates="conversationMessage")
+    user: Mapped["User"] = relationship("User", back_populates="conversationMessage", uselist=False)
+
+
+class Learning(Base):
+    __tablename__ = "Learning"
+    __table_args__ = {'schema': 'public'}
+
+    id: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
+    userId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.User.id"), nullable=False)
+    summary: Mapped[str] = mapped_column(Text, nullable=False)
+    createdAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
+    updatedAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now())
+
+    # Relationships
+    _ConversationMessageToLearning: Mapped[List["_ConversationMessageToLearning"]] = relationship("_ConversationMessageToLearning", back_populates="learning")
+    user: Mapped["User"] = relationship("User", back_populates="learning", uselist=False)
+
+
 class Session(Base):
     __tablename__ = "Session"
     __table_args__ = {'schema': 'public'}
@@ -107,9 +144,9 @@ class User(Base):
     account: Mapped[List["Account"]] = relationship("Account", back_populates="user")
     session: Mapped[List["Session"]] = relationship("Session", back_populates="user")
     authenticator: Mapped[List["Authenticator"]] = relationship("Authenticator", back_populates="user")
-    conversation_messages: Mapped[List["ConversationMessage"]] = relationship("ConversationMessage", back_populates="user")
-    learnings: Mapped[List["Learning"]] = relationship("Learning", back_populates="user")
-    
+    conversationMessage: Mapped[List["ConversationMessage"]] = relationship("ConversationMessage", back_populates="user")
+    learning: Mapped[List["Learning"]] = relationship("Learning", back_populates="user")
+
 class Vector(TypeDecorator):
     """Custom type for PostgreSQL vector type"""
     impl = String
@@ -138,6 +175,18 @@ class VerificationToken(Base):
     expires: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
 
 
+class _ConversationMessageToLearning(Base):
+    __tablename__ = "_ConversationMessageToLearning"
+    __table_args__ = {'schema': 'public'}
+
+    A: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.ConversationMessage.messageId"), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
+    B: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.Learning.id"), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
+
+    # Relationships
+    conversationMessage: Mapped["ConversationMessage"] = relationship("ConversationMessage", back_populates="_ConversationMessageToLearning", uselist=False)
+    learning: Mapped["Learning"] = relationship("Learning", back_populates="_ConversationMessageToLearning", uselist=False)
+
+
 class _prisma_migrations(Base):
     __tablename__ = "_prisma_migrations"
     __table_args__ = {'schema': 'public'}
@@ -151,42 +200,3 @@ class _prisma_migrations(Base):
     started_at: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False)
     applied_steps_count: Mapped[int] = mapped_column(Integer, nullable=False)
 
-class MessageSender(enum.Enum):
-    USER = "USER"
-    AI = "AI"
-
-# Relationship between ConversationMessage and Learning
-t_ConversationMessageToLearning = Table(
-    '_ConversationMessageToLearning', Base.metadata,
-    Column('A', PostgresUUID(as_uuid=True), ForeignKey('public.ConversationMessage.messageId'), primary_key=True, nullable=False),
-    Column('B', PostgresUUID(as_uuid=True), ForeignKey('public.Learning.id'), primary_key=True, nullable=False),
-    schema='public'
-)
-
-class ConversationMessage(Base):
-    __tablename__ = "ConversationMessage"
-    __table_args__ = {'schema': 'public'}
-
-    messageId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
-    userId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.User.id"), nullable=False)
-    sender: Mapped[MessageSender] = mapped_column(ENUM(MessageSender, name="MessageSender"), nullable=False)
-    content: Mapped[str] = mapped_column(Text, nullable=False)
-    createdAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
-
-    # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="conversation_messages")
-    learnings: Mapped[List["Learning"]] = relationship("Learning", secondary=t_ConversationMessageToLearning, back_populates="messages")
-
-class Learning(Base):
-    __tablename__ = "Learning"
-    __table_args__ = {'schema': 'public'}
-
-    id: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), primary_key=True, nullable=False, server_default=text("gen_random_uuid()"))
-    userId: Mapped[UUID] = mapped_column(PostgresUUID(as_uuid=True), ForeignKey("public.User.id"), nullable=False)
-    summary: Mapped[str] = mapped_column(Text, nullable=False)
-    createdAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now())
-    updatedAt: Mapped[datetime] = mapped_column(TIMESTAMP, nullable=False, server_default=func.now(), onupdate=func.now())
-
-    # Relationships
-    user: Mapped["User"] = relationship("User", back_populates="learnings")
-    messages: Mapped[List["ConversationMessage"]] = relationship("ConversationMessage", secondary=t_ConversationMessageToLearning, back_populates="learnings")


### PR DESCRIPTION
- Added learning schema (issue #68)
- Prisma automatically created many-to-many relationship schema `_ConversationMessageToLearning`
- Formatted prisma files with command `npx prisma format`
- Added a simple test for adding a new learning

Copied test instructions from PR #81:

Connect to the local DB with:
`sudo docker exec -it $(docker ps -q --filter name=lv-db) psql -U postgres`
List tables with `\dt`
You should see a table called "Learning" among others

### Unit testing (run all in the root folder):
1. Remove old test DB (if any)
`docker compose --profile tests down -v`
3. Start the Postgres test DB
`docker compose --profile tests up -d test-postgres`
5. Run migrations
`docker compose --profile tests run --rm test-migrate`
7. Finally, run the unit tests
`docker compose --profile tests run --rm test-runner`