### PR TITLE
Automate PR reviewer assignment

### DIFF
--- a/.github/workflows/AutoAssign-Reviewers.yml
+++ b/.github/workflows/AutoAssign-Reviewers.yml
@@ -1,0 +1,77 @@
+name: Auto Assign PR Reviewers
+
+on:
+  pull_request:
+    branches: [aari/automate-pr-reviews] 
+    types: [opened, ready_for_review]
+
+jobs:
+  assign:
+    permissions:
+      pull-requests: write
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Get Reviewers
+        id: filter
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const reviewers = ${{ vars.REVIEWERS }}
+            const author = context.payload.pull_request.user.login
+
+            const { data: openPRs } = await github.rest.pulls.list({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              state: 'open',
+            });
+
+            const assignedPRsperReviewer = {}
+            reviewers.forEach(r => assignedPRsperReviewer[r] = 0)
+
+            for (const pr of openPRs) {
+              if (pr.number === context.payload.pull_request.number) continue;
+
+              const { data: requested } = await github.rest.pulls.listRequestedReviewers({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                pull_number: pr.number
+              });
+
+              // Update counts for each reviewer
+              requested.users.forEach(user => {
+                if (reviewers.includes(user.login)) {
+                  assignedPRsperReviewer[user.login] += 1
+                }
+              });
+            }
+            // Get relevant reviewers
+            const finalReviewers = reviewers.filter(r => r !== author)
+            .filter(r => assignedPRsperReviewer[r] < 2)
+
+            console.log('Review counts:', assignedPRsperReviewer);
+            console.log('Eligible reviewers:', finalReviewers);
+            
+            return finalReviewers.join(', ')
+          result-encoding: string
+
+      - name: Assign Reviewers
+        uses: hkusu/review-assign-action@v1
+        with:
+          assignees: ${{ github.actor }}
+          reviewers: ${{ steps.filter.outputs.result }}
+          max-num-of-reviewers: 2
+          ready-comment: 'PR #${{ github.event.pull_request.number }} is Ready for review'
+          merged-comment: 'PR #${{ github.event.pull_request.number }} was merged. Thanks for your review :wink:'
+
+      - name: Notify if no reviewers available
+        if: steps.filter.outputs.result == ''
+        uses: actions/github-script@v7
+        with:
+          script: |
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: context.payload.pull_request.number,
+              body: '**No reviewers available** - All eligible reviewers currently have 2 or more PRs assigned. Please assign a reviewer manually or wait for current reviews to be completed.'
+            });

--- a/.github/workflows/AutoAssign-Reviewers.yml
+++ b/.github/workflows/AutoAssign-Reviewers.yml
@@ -2,7 +2,7 @@ name: Auto Assign PR Reviewers
 
 on:
   pull_request:
-    branches: [aari/automate-pr-reviews] 
+    branches: [main, dev] 
     types: [opened, ready_for_review]
 
 jobs:


### PR DESCRIPTION
Automate PR reviewer assignment.
Added new workflow that runs when a PR is **open AND ready for review**. 
Current limit for reviews is 2per developer but can be changed if needed.
In case no reviewers are available we will have to manually assign and will be notified.