### PR TITLE
make gcp run prod environment automatically

### DIFF
--- a/apps/lv-pyapi/agent.py
+++ b/apps/lv-pyapi/agent.py
@@ -63,8 +63,10 @@ def _run_worker_process():
     """
     Runs the LiveKit Worker in a separate process.
     """
-    sys.argv = ["agent.py", "dev"]
-    # sys.argv = ["agent.py", "start"] # production
+    # Use "start" in Google Cloud Run, "dev" in local development
+    is_cloud_run = os.environ.get("K_SERVICE") is not None
+    command = "start" if is_cloud_run else "dev"
+    sys.argv = ["agent.py", command]
     logger.info(f"Starting Voice Agent Worker '{AGENT_NAME}' connecting to {LIVEKIT_URL}...")
     
     agents.cli.run_app(server)


### PR DESCRIPTION
Change the livekit agent worker to run on production mode in Cloud Run and in Dev when developing locally.