### PR TITLE
Fix pyapi docker with libglib

### DIFF
--- a/apps/lv-pyapi/Dockerfile
+++ b/apps/lv-pyapi/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /app
 RUN apt-get update && apt-get install -y \
     gcc \
     postgresql-client \
+    libglib2.0-0 \
     && rm -rf /var/lib/apt/lists/*
 
 # Copy requirements and install Python dependencies


### PR DESCRIPTION
Fix OSerror if libglib is missing