### PR TITLE
change deployment prisma conf from dev to deploy

### DIFF
--- a/.github/workflows/CD.yml
+++ b/.github/workflows/CD.yml
@@ -66,7 +66,7 @@ jobs:
         env:
           DATABASE_URL: postgresql://${{ secrets.PGUSER }}:${{ env.PGPASSWORD_URLENCODED }}@127.0.0.1:5432/${{ secrets.PGDATABASE }}?schema=public
           DIRECT_DATABASE_URL: postgresql://${{ secrets.PGUSER }}:${{ env.PGPASSWORD_URLENCODED }}@127.0.0.1:5432/${{ secrets.PGDATABASE }}?schema=public
-        run: npx turbo run db:migrate
+        run: npx prisma migrate deploy --schema ./packages/database/prisma/schema/schema.prisma
 
       - name: Build and push backend Docker image
         uses: docker/build-push-action@v5


### PR DESCRIPTION
Our database schema sync to cloud sql was configured as prisma migrate dev. However, dev is for local and prisma migrate deploy is meant for Github Actions deployments. 

