### PR TITLE
Add needed context files for agent so it works on livekit cloud

### DIFF
--- a/.github/workflows/agent-deployment.yml
+++ b/.github/workflows/agent-deployment.yml
@@ -16,6 +16,14 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
 
+      - name: Inject shared modules into agent build context
+        # Copies files that live outside agents/ into agents/ so Docker can reach them.
+        # These paths are .gitignored — nothing is committed to the repo.
+        run: |
+          cp apps/lv-pyapi/database.py      apps/lv-pyapi/agents/database.py
+          cp apps/lv-pyapi/gemini_client.py  apps/lv-pyapi/agents/gemini_client.py
+          cp -r packages/python-utils/src/python_utils apps/lv-pyapi/agents/python_utils
+
       - name: Deploy to LiveKit Cloud
         uses: livekit/deploy-action@v2.12.1
         with:

--- a/apps/lv-pyapi/agents/.gitignore
+++ b/apps/lv-pyapi/agents/.gitignore
@@ -1,0 +1,5 @@
+# Files injected by CI (agent-deployment.yml) before the Docker build.
+# These are copies of files from elsewhere in the monorepo and must NOT be committed.
+database.py
+gemini_client.py
+python_utils/

--- a/apps/lv-pyapi/agents/Dockerfile
+++ b/apps/lv-pyapi/agents/Dockerfile
@@ -1,4 +1,8 @@
 # Build context is apps/lv-pyapi/agents/ (used by the LiveKit deploy action)
+# Before this Dockerfile runs, the CI workflow copies these into agents/:
+#   - database.py       (from apps/lv-pyapi/)
+#   - gemini_client.py  (from apps/lv-pyapi/)
+#   - python_utils/     (from packages/python-utils/src/python_utils/)
 FROM python:3.11-slim
 
 WORKDIR /app
@@ -8,15 +12,21 @@ RUN apt-get update && apt-get install -y \
     gcc \
     && rm -rf /var/lib/apt/lists/*
 
-# Copy and install agent-specific dependencies
+# Copy and install dependencies
 COPY requirements.txt ./requirements.txt
 RUN pip install --no-cache-dir -r requirements.txt
 
-# Copy the agent and its task definitions
-COPY agent.py ./agents/agent.py
-COPY tasks.py ./tasks.py
+# Copy shared modules (injected by CI — see agent-deployment.yml)
+COPY database.py ./database.py
+COPY gemini_client.py ./gemini_client.py
+COPY python_utils/ ./python_utils/
 
-# Make the pyapi root (tasks.py) importable
+# Copy agent source files
+COPY agent.py ./agents/agent.py
+COPY tasks.py ./agents/tasks.py
+COPY learnings.py ./agents/learnings.py
+
+# /app is the root — database.py, gemini_client.py, python_utils/ and agents/ are all importable
 ENV PYTHONPATH=/app
 
 # Run the agent

--- a/apps/lv-pyapi/agents/requirements.txt
+++ b/apps/lv-pyapi/agents/requirements.txt
@@ -2,3 +2,8 @@ livekit-agents[google]~=1.3
 livekit-agents[elevenlabs]~=1.3
 livekit-agents[silero]~=1.3
 python-dotenv==1.1.0
+# Shared lv-pyapi deps (needed by database.py, gemini_client.py, learnings.py)
+sqlalchemy==2.0.27
+psycopg2-binary==2.9.9
+google-genai==1.55.0
+pgvector==0.4.2


### PR DESCRIPTION
The agent.py which is deployed to livekit cloud does not bake the learnings.py or other files learnings.py uses. With this pr I inject the files to the agent dockerfile during CI