### PR TITLE
Add dynamic job count

### DIFF
--- a/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
@@ -124,7 +124,7 @@ describe('Dashboard Sidebar', () => {
     });
     (getMatchedJobs as jest.Mock).mockResolvedValue({
       jobs: [{ id: 'job-1' }, { id: 'job-2' }, { id: 'job-3' }],
-      total: 7,
+      total: 3,
       has_more: false,
     });
   });

--- a/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
@@ -4,6 +4,7 @@ import userEvent from '@testing-library/user-event';
 import { signOut, useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
 import { ReactNode } from 'react';
+import { getMatchedJobs } from '../../lib/services/pyapi';
 
 interface SidebarMenuButtonProps {
   children: ReactNode;
@@ -36,6 +37,10 @@ jest.mock('next/navigation', () => ({
 jest.mock('next-auth/react', () => ({
   useSession: jest.fn(),
   signOut: jest.fn(),
+}));
+
+jest.mock('../../lib/services/pyapi', () => ({
+  getMatchedJobs: jest.fn(),
 }));
 
 // Mock sidebar components
@@ -117,6 +122,11 @@ describe('Dashboard Sidebar', () => {
       data: mockSession,
       status: 'authenticated',
     });
+    (getMatchedJobs as jest.Mock).mockResolvedValue({
+      jobs: [{ id: 'job-1' }, { id: 'job-2' }, { id: 'job-3' }],
+      total: 7,
+      has_more: false,
+    });
   });
 
   it('renders sidebar', () => {
@@ -141,6 +151,49 @@ describe('Dashboard Sidebar', () => {
     expect(sidebarItems.length).toBeGreaterThan(0);
     expect(screen.getByText('Opportunities')).toBeInTheDocument();
     expect(screen.getAllByText('Profile').length).toBeGreaterThan(0);
+  });
+
+  it('shows dynamic opportunities count', async () => {
+    (usePathname as jest.Mock).mockReturnValue('/dashboard/opportunities');
+
+    render(
+      <DashboardLayout>
+        <div>Test Content</div>
+      </DashboardLayout>
+    );
+
+    expect(await screen.findByText('3')).toBeInTheDocument();
+    expect(getMatchedJobs).toHaveBeenCalledWith('1');
+  });
+
+  it('hides opportunities count badge when count is zero', async () => {
+    (usePathname as jest.Mock).mockReturnValue('/dashboard/opportunities');
+    (getMatchedJobs as jest.Mock).mockResolvedValueOnce({
+      jobs: [],
+      total: 0,
+      has_more: false,
+    });
+
+    render(
+      <DashboardLayout>
+        <div>Test Content</div>
+      </DashboardLayout>
+    );
+
+    await screen.findAllByText('Opportunities');
+    expect(screen.queryByText('0')).not.toBeInTheDocument();
+  });
+
+  it('does not recalculate count outside opportunities page', () => {
+    (usePathname as jest.Mock).mockReturnValue('/dashboard/profile');
+
+    render(
+      <DashboardLayout>
+        <div>Test Content</div>
+      </DashboardLayout>
+    );
+
+    expect(getMatchedJobs).not.toHaveBeenCalled();
   });
 
   it('shows active state for current page', () => {

--- a/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
@@ -286,7 +286,6 @@ describe('Dashboard Sidebar', () => {
 
   it('calls signOut when sign out clicked', async () => {
     const user = userEvent.setup();
-    sessionStorage.setItem('sidebar-open', 'true');
     sessionStorage.setItem('opportunities-count', '3');
 
     render(
@@ -297,7 +296,6 @@ describe('Dashboard Sidebar', () => {
 
     const signOutButton = screen.getByText('Sign Out');
     await user.click(signOutButton);
-    expect(sessionStorage.getItem('sidebar-open')).toBeNull();
     expect(sessionStorage.getItem('opportunities-count')).toBeNull();
     expect(signOut).toHaveBeenCalledWith({ callbackUrl: '/login' });
   });

--- a/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
@@ -286,6 +286,8 @@ describe('Dashboard Sidebar', () => {
 
   it('calls signOut when sign out clicked', async () => {
     const user = userEvent.setup();
+    sessionStorage.setItem('sidebar-open', 'true');
+    sessionStorage.setItem('opportunities-count', '3');
 
     render(
       <DashboardLayout>
@@ -295,6 +297,8 @@ describe('Dashboard Sidebar', () => {
 
     const signOutButton = screen.getByText('Sign Out');
     await user.click(signOutButton);
+    expect(sessionStorage.getItem('sidebar-open')).toBeNull();
+    expect(sessionStorage.getItem('opportunities-count')).toBeNull();
     expect(signOut).toHaveBeenCalledWith({ callbackUrl: '/login' });
   });
 

--- a/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
@@ -116,6 +116,7 @@ describe('Dashboard Sidebar', () => {
 
   beforeEach(() => {
     jest.clearAllMocks();
+    sessionStorage.clear();
     (useRouter as jest.Mock).mockReturnValue(mockRouter);
     (usePathname as jest.Mock).mockReturnValue('/dashboard/interview');
     (useSession as jest.Mock).mockReturnValue({
@@ -127,6 +128,10 @@ describe('Dashboard Sidebar', () => {
       total: 3,
       has_more: false,
     });
+  });
+
+  afterEach(() => {
+    sessionStorage.clear();
   });
 
   it('renders sidebar', () => {

--- a/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
+++ b/apps/lv-web/src/__tests__/unit/dashboard-sidebar.test.tsx
@@ -1,5 +1,5 @@
 import DashboardLayout from '@/app/dashboard/layout';
-import { render, screen } from '@testing-library/react';
+import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { signOut, useSession } from 'next-auth/react';
 import { usePathname, useRouter } from 'next/navigation';
@@ -154,8 +154,6 @@ describe('Dashboard Sidebar', () => {
   });
 
   it('shows dynamic opportunities count', async () => {
-    (usePathname as jest.Mock).mockReturnValue('/dashboard/opportunities');
-
     render(
       <DashboardLayout>
         <div>Test Content</div>
@@ -167,7 +165,6 @@ describe('Dashboard Sidebar', () => {
   });
 
   it('hides opportunities count badge when count is zero', async () => {
-    (usePathname as jest.Mock).mockReturnValue('/dashboard/opportunities');
     (getMatchedJobs as jest.Mock).mockResolvedValueOnce({
       jobs: [],
       total: 0,
@@ -184,16 +181,48 @@ describe('Dashboard Sidebar', () => {
     expect(screen.queryByText('0')).not.toBeInTheDocument();
   });
 
-  it('does not recalculate count outside opportunities page', () => {
-    (usePathname as jest.Mock).mockReturnValue('/dashboard/profile');
-
-    render(
+  it('calculates opportunities count once on app open', async () => {
+    const { rerender } = render(
       <DashboardLayout>
         <div>Test Content</div>
       </DashboardLayout>
     );
 
-    expect(getMatchedJobs).not.toHaveBeenCalled();
+    await screen.findByText('3');
+
+    rerender(
+      <DashboardLayout>
+        <div>Test Content Updated</div>
+      </DashboardLayout>
+    );
+
+    expect(getMatchedJobs).toHaveBeenCalledTimes(1);
+  });
+
+  it('recalculates opportunities count when entering opportunities page', async () => {
+    (usePathname as jest.Mock).mockReturnValue('/dashboard/profile');
+
+    const { rerender } = render(
+      <DashboardLayout>
+        <div>Test Content</div>
+      </DashboardLayout>
+    );
+
+    await waitFor(() => {
+      expect(getMatchedJobs).toHaveBeenCalledTimes(1);
+    });
+
+    (usePathname as jest.Mock).mockReturnValue('/dashboard/opportunities');
+
+    rerender(
+      <DashboardLayout>
+        <div>Test Content</div>
+      </DashboardLayout>
+    );
+
+    await waitFor(() => {
+      expect(getMatchedJobs).toHaveBeenCalledTimes(2);
+    });
   });
 
   it('shows active state for current page', () => {

--- a/apps/lv-web/src/app/dashboard/layout.tsx
+++ b/apps/lv-web/src/app/dashboard/layout.tsx
@@ -35,6 +35,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   const { data: session, status } = useSession();
   const [isHovering, setIsHovering] = useState(false);
   const [opportunitiesCount, setOpportunitiesCount] = useState(0);
+  const hasFetchedOpportunitiesCountRef = useRef(false);
   const previousPathnameRef = useRef<string | null>(null);
 
   // Save to sessionStorage when sidebar state changes
@@ -100,11 +101,26 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   }, []);
 
   useEffect(() => {
+    if (!session?.user?.id || hasFetchedOpportunitiesCountRef.current) {
+      return;
+    }
+
+    hasFetchedOpportunitiesCountRef.current = true;
+    fetchOpportunitiesCount();
+  }, [session?.user?.id, fetchOpportunitiesCount]);
+
+  useEffect(() => {
     const previousPathname = previousPathnameRef.current;
+
+    // Skip first render to avoid duplicate fetch when landing directly on opportunities.
+    if (previousPathname === null) {
+      previousPathnameRef.current = pathname;
+      return;
+    }
 
     if (
       pathname?.startsWith('/dashboard/opportunities') &&
-      !previousPathname?.startsWith('/dashboard/opportunities')
+      !previousPathname.startsWith('/dashboard/opportunities')
     ) {
       fetchOpportunitiesCount();
     }

--- a/apps/lv-web/src/app/dashboard/layout.tsx
+++ b/apps/lv-web/src/app/dashboard/layout.tsx
@@ -62,7 +62,6 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
 
   const handleSignOut = () => {
     if (typeof window !== 'undefined') {
-      sessionStorage.removeItem('sidebar-open');
       sessionStorage.removeItem(OPPORTUNITIES_COUNT_STORAGE_KEY);
     }
     signOut({ callbackUrl: '/login' });

--- a/apps/lv-web/src/app/dashboard/layout.tsx
+++ b/apps/lv-web/src/app/dashboard/layout.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import { getMatchedJobs } from '@/lib/services/pyapi';
 import {
   DropdownMenu,
   DropdownMenuContent,
@@ -23,7 +24,9 @@ import { Briefcase, ChevronDown, Database, LogOut, Menu, Phone, Shield, User } f
 import { signOut, useSession } from 'next-auth/react';
 import Image from 'next/image';
 import { usePathname, useRouter } from 'next/navigation';
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
+
+const OPPORTUNITIES_COUNT_STORAGE_KEY = 'opportunities-count';
 
 function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   const { toggleSidebar, open } = useSidebar();
@@ -31,6 +34,8 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   const pathname = usePathname();
   const { data: session, status } = useSession();
   const [isHovering, setIsHovering] = useState(false);
+  const [opportunitiesCount, setOpportunitiesCount] = useState(0);
+  const previousPathnameRef = useRef<string | null>(null);
 
   // Save to sessionStorage when sidebar state changes
   useEffect(() => {
@@ -59,6 +64,53 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
       router.push('/login');
     }
   }, [status, router]);
+
+  const fetchOpportunitiesCount = useCallback(async () => {
+    if (!session?.user?.id) {
+      setOpportunitiesCount(0);
+      return;
+    }
+
+    try {
+      // Keep badge aligned with opportunities page fetch behavior.
+      const matchResponse = await getMatchedJobs(session.user.id);
+      const count = matchResponse.jobs.length;
+      setOpportunitiesCount(count);
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem(OPPORTUNITIES_COUNT_STORAGE_KEY, String(count));
+      }
+    } catch {
+      // Missing embedding and request failures should show zero.
+      setOpportunitiesCount(0);
+      if (typeof window !== 'undefined') {
+        sessionStorage.setItem(OPPORTUNITIES_COUNT_STORAGE_KEY, '0');
+      }
+    }
+  }, [session?.user?.id]);
+
+  useEffect(() => {
+    if (typeof window === 'undefined') return;
+    const storedCount = sessionStorage.getItem(OPPORTUNITIES_COUNT_STORAGE_KEY);
+    if (storedCount === null) return;
+
+    const parsed = Number.parseInt(storedCount, 10);
+    if (!Number.isNaN(parsed) && parsed >= 0) {
+      setOpportunitiesCount(parsed);
+    }
+  }, []);
+
+  useEffect(() => {
+    const previousPathname = previousPathnameRef.current;
+
+    if (
+      pathname?.startsWith('/dashboard/opportunities') &&
+      !previousPathname?.startsWith('/dashboard/opportunities')
+    ) {
+      fetchOpportunitiesCount();
+    }
+
+    previousPathnameRef.current = pathname;
+  }, [pathname, fetchOpportunitiesCount]);
 
   if (status === 'loading') {
     return (
@@ -181,9 +233,11 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                         Opportunities
                       </span>
                     </div>
-                    <span className="px-2 py-0.5 bg-gray-300 text-gray-700 text-xs rounded-full font-medium">
-                      3
-                    </span>
+                    {opportunitiesCount > 0 && (
+                      <span className="px-2 py-0.5 bg-gray-300 text-gray-700 text-xs rounded-full font-medium">
+                        {opportunitiesCount}
+                      </span>
+                    )}
                   </SidebarMenuButton>
                 </SidebarMenuItem>
 
@@ -226,7 +280,9 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                       isActive={pathname?.startsWith('/admin/users')}
                       tooltip="Admin"
                       style={
-                        pathname?.startsWith('/admin/users') ? { backgroundColor: 'var(--bg-hover)' } : {}
+                        pathname?.startsWith('/admin/users')
+                          ? { backgroundColor: 'var(--bg-hover)' }
+                          : {}
                       }
                       className="justify-between hover:bg-blue-50"
                     >
@@ -268,9 +324,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                         />
                         <span
                           className={
-                            pathname?.startsWith('/admin/jobs')
-                              ? 'text-gray-900'
-                              : 'text-gray-600'
+                            pathname?.startsWith('/admin/jobs') ? 'text-gray-900' : 'text-gray-600'
                           }
                         >
                           Upload Jobs

--- a/apps/lv-web/src/app/dashboard/layout.tsx
+++ b/apps/lv-web/src/app/dashboard/layout.tsx
@@ -60,6 +60,14 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
     }
   };
 
+  const handleSignOut = () => {
+    if (typeof window !== 'undefined') {
+      sessionStorage.removeItem('sidebar-open');
+      sessionStorage.removeItem(OPPORTUNITIES_COUNT_STORAGE_KEY);
+    }
+    signOut({ callbackUrl: '/login' });
+  };
+
   useEffect(() => {
     if (status === 'unauthenticated') {
       router.push('/login');
@@ -391,10 +399,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                   </SidebarMenuButton>
                 </DropdownMenuTrigger>
                 <DropdownMenuContent align="end" className="w-56">
-                  <DropdownMenuItem
-                    onClick={() => signOut({ callbackUrl: '/login' })}
-                    className="text-red-600 cursor-pointer"
-                  >
+                  <DropdownMenuItem onClick={handleSignOut} className="text-red-600 cursor-pointer">
                     <LogOut className="w-4 h-4 mr-2" />
                     Sign Out
                   </DropdownMenuItem>


### PR DESCRIPTION
PR for issue #222
- Saves the count to sessionstorage
- Calculates the count once when you open the app, recalculates when entering opportunities page