### PR TITLE
add functionality for refreshing job embeddings from admin interface

### DIFF
--- a/apps/lv-web/src/__tests__/unit/admin-job-embeddings-stats-route.test.ts
+++ b/apps/lv-web/src/__tests__/unit/admin-job-embeddings-stats-route.test.ts
@@ -1,0 +1,99 @@
+jest.mock('@repo/db', () => ({
+  prisma: {
+    $queryRawUnsafe: jest.fn(),
+  },
+}));
+
+jest.mock('@repo/lib', () => ({
+  requireAdminAuth: jest.fn(),
+}));
+
+jest.mock('next/server', () => ({
+  NextResponse: {
+    json: (body: unknown, init?: { status?: number }) => ({
+      status: init?.status ?? 200,
+      json: async () => body,
+    }),
+  },
+}));
+
+import { prisma } from '@repo/db';
+import { requireAdminAuth } from '@repo/lib';
+import { GET } from '../../app/api/admin/job-embeddings/stats/route';
+
+const mockQuery = prisma.$queryRawUnsafe as jest.Mock;
+const mockRequireAdminAuth = requireAdminAuth as jest.Mock;
+
+describe('GET /api/admin/job-embeddings/stats', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockRequireAdminAuth.mockResolvedValue(null);
+  });
+
+  it('returns counts derived from the Job table', async () => {
+    mockQuery.mockResolvedValueOnce([{ total: 100, with_embeddings: 73 }]);
+
+    const res = await GET();
+
+    expect(mockRequireAdminAuth).toHaveBeenCalled();
+    expect(mockQuery).toHaveBeenCalledWith(
+      expect.stringContaining('COUNT(*)::int AS total'),
+    );
+    expect(mockQuery).toHaveBeenCalledWith(expect.stringContaining('FROM "Job"'));
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      totalJobs: 100,
+      jobsWithEmbeddings: 73,
+      missingEmbeddings: 27,
+    });
+  });
+
+  it('never returns a negative missingEmbeddings count', async () => {
+    mockQuery.mockResolvedValueOnce([{ total: 10, with_embeddings: 15 }]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      totalJobs: 10,
+      jobsWithEmbeddings: 15,
+      missingEmbeddings: 0,
+    });
+  });
+
+  it('treats an empty query result as zero jobs', async () => {
+    mockQuery.mockResolvedValueOnce([]);
+
+    const res = await GET();
+
+    expect(res.status).toBe(200);
+    expect(await res.json()).toEqual({
+      totalJobs: 0,
+      jobsWithEmbeddings: 0,
+      missingEmbeddings: 0,
+    });
+  });
+
+  it('returns the auth error response when the caller is not an admin', async () => {
+    mockRequireAdminAuth.mockResolvedValueOnce({
+      status: 403,
+      json: async () => ({ error: 'Forbidden - Admin access required' }),
+    });
+
+    const res = await GET();
+
+    expect(mockQuery).not.toHaveBeenCalled();
+    expect(res.status).toBe(403);
+  });
+
+  it('returns 500 when the database query fails', async () => {
+    const logSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    mockQuery.mockRejectedValueOnce(new Error('connection refused'));
+
+    const res = await GET();
+
+    expect(res.status).toBe(500);
+    expect(await res.json()).toMatchObject({ error: 'Internal server error' });
+    logSpy.mockRestore();
+  });
+});

--- a/apps/lv-web/src/__tests__/unit/pyapi-generate-embeddings.test.ts
+++ b/apps/lv-web/src/__tests__/unit/pyapi-generate-embeddings.test.ts
@@ -1,0 +1,80 @@
+jest.mock('../../config', () => ({
+  PYAPI_URL: 'https://pyapi.test',
+}));
+
+import { generateJobEmbeddings } from '@/lib/services/pyapi';
+
+describe('generateJobEmbeddings', () => {
+  const originalFetch = global.fetch;
+
+  beforeEach(() => {
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  it('POSTs to the generate-embeddings endpoint and returns the payload', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ status: 200, message: 'Embedding generation started in background' }),
+    });
+
+    const result = await generateJobEmbeddings();
+
+    expect(global.fetch).toHaveBeenCalledWith('https://pyapi.test/api/jobs/generate-embeddings', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({}),
+    });
+    expect(result).toEqual({
+      status: 200,
+      message: 'Embedding generation started in background',
+    });
+  });
+
+  it('prefers message over detail when the response is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Bad Request',
+      json: async () => ({ message: 'Custom failure' }),
+    });
+
+    await expect(generateJobEmbeddings()).rejects.toThrow('Custom failure');
+  });
+
+  it('stringifies FastAPI string detail when the response is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Unprocessable Entity',
+      json: async () => ({ detail: 'Invalid payload' }),
+    });
+
+    await expect(generateJobEmbeddings()).rejects.toThrow('Invalid payload');
+  });
+
+  it('joins FastAPI validation detail messages when the response is not ok', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Unprocessable Entity',
+      json: async () => ({
+        detail: [{ msg: 'field required' }, { msg: 'too short' }],
+      }),
+    });
+
+    await expect(generateJobEmbeddings()).rejects.toThrow('field required, too short');
+  });
+
+  it('falls back to statusText when no message or detail is present', async () => {
+    (global.fetch as jest.Mock).mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Gateway Timeout',
+      json: async () => ({}),
+    });
+
+    await expect(generateJobEmbeddings()).rejects.toThrow(
+      'Failed to start embedding generation: Gateway Timeout',
+    );
+  });
+});

--- a/apps/lv-web/src/app/admin/jobs/page.tsx
+++ b/apps/lv-web/src/app/admin/jobs/page.tsx
@@ -1,101 +1,328 @@
 'use client';
 
-import { uploadJobs } from '@/lib/services/pyapi';
-import { useState } from 'react';
+import type { AdminJobEmbeddingStats } from '@/types/admin';
+import { generateJobEmbeddings, uploadJobs } from '@/lib/services/pyapi';
+import {
+  AlertDialog,
+  AlertDialogAction,
+  AlertDialogCancel,
+  AlertDialogContent,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogHeader,
+  AlertDialogTitle,
+} from '@repo/ui/components/alert-dialog';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@repo/ui/components/tabs';
+import { useCallback, useEffect, useState } from 'react';
+
+const LAST_EMBEDDING_TRIGGER_KEY = 'lv-admin-job-embeddings-last-trigger';
 
 export default function AdminJobsPage() {
-  const [filename, setFilename] = useState('');
-  const [loading, setLoading] = useState(false);
-  const [response, setResponse] = useState<{ message: string; status: number } | null>(null);
-  const [error, setError] = useState('');
+  const [activeTab, setActiveTab] = useState('upload');
 
-  const handleSubmit = async (e: React.FormEvent) => {
+  const [filename, setFilename] = useState('');
+  const [uploadLoading, setUploadLoading] = useState(false);
+  const [uploadResponse, setUploadResponse] = useState<{ message: string; status: number } | null>(null);
+  const [uploadError, setUploadError] = useState('');
+
+  const [stats, setStats] = useState<AdminJobEmbeddingStats | null>(null);
+  const [statsLoading, setStatsLoading] = useState(false);
+  const [statsError, setStatsError] = useState('');
+
+  const [embedConfirmOpen, setEmbedConfirmOpen] = useState(false);
+  const [embedLoading, setEmbedLoading] = useState(false);
+  const [embedResponse, setEmbedResponse] = useState<{ message: string; status: number } | null>(null);
+  const [embedError, setEmbedError] = useState('');
+  const [lastTriggeredAt, setLastTriggeredAt] = useState<string | null>(() => {
+    if (typeof window === 'undefined') return null;
+    return sessionStorage.getItem(LAST_EMBEDDING_TRIGGER_KEY);
+  });
+
+  const loadStats = useCallback(async () => {
+    setStatsLoading(true);
+    setStatsError('');
+    try {
+      const res = await fetch('/api/admin/job-embeddings/stats');
+      if (!res.ok) {
+        const body = await res.json().catch(() => ({}));
+        throw new Error(body.error || `Failed to load stats (${res.status})`);
+      }
+      const data: AdminJobEmbeddingStats = await res.json();
+      setStats(data);
+    } catch (err) {
+      setStatsError(err instanceof Error ? err.message : 'Failed to load embedding stats');
+      setStats(null);
+    } finally {
+      setStatsLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    if (activeTab === 'embeddings') {
+      void loadStats();
+    }
+  }, [activeTab, loadStats]);
+
+  const handleUploadSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
 
     if (!filename.trim()) {
-      setError('Please enter a filename');
+      setUploadError('Please enter a filename');
       return;
     }
 
-    setLoading(true);
-    setError('');
-    setResponse(null);
+    setUploadLoading(true);
+    setUploadError('');
+    setUploadResponse(null);
 
     try {
       const result = await uploadJobs(filename);
-      setResponse(result);
+      setUploadResponse(result);
     } catch (err) {
-      setError(err instanceof Error ? err.message : 'Failed to upload jobs');
+      setUploadError(err instanceof Error ? err.message : 'Failed to upload jobs');
     } finally {
-      setLoading(false);
+      setUploadLoading(false);
+    }
+  };
+
+  const handleConfirmGenerateEmbeddings = async () => {
+    setEmbedConfirmOpen(false);
+    setEmbedLoading(true);
+    setEmbedError('');
+    setEmbedResponse(null);
+
+    try {
+      const result = await generateJobEmbeddings();
+      setEmbedResponse(result);
+      const iso = new Date().toISOString();
+      sessionStorage.setItem(LAST_EMBEDDING_TRIGGER_KEY, iso);
+      setLastTriggeredAt(iso);
+      void loadStats();
+    } catch (err) {
+      setEmbedError(err instanceof Error ? err.message : 'Failed to start embedding generation');
+    } finally {
+      setEmbedLoading(false);
     }
   };
 
   return (
     <div className="p-8">
-      <div className="bg-white rounded-lg shadow p-6 mb-6">
-        <h2 className="text-xl font-semibold mb-4">Upload jobs from Google Cloud Storage to the database</h2>
+      <Tabs value={activeTab} onValueChange={setActiveTab} className="w-full max-w-4xl">
+        <TabsList className="bg-gray-100 mb-4">
+          <TabsTrigger value="upload">Upload job data</TabsTrigger>
+          <TabsTrigger value="embeddings">Job embeddings</TabsTrigger>
+        </TabsList>
 
-        <form onSubmit={handleSubmit}>
-          <div className="mb-4">
-            <label className="block text-sm font-medium mb-2">Enter CSV Filename</label>
-            <div className="flex items-center border border-gray-300 rounded-lg focus-within:ring-2 focus-within:ring-blue-500">
-              <span className="px-3 py-2 bg-gray-100 text-gray-600 border-r border-gray-300 whitespace-nowrap rounded-l-lg">
-                lv-storage/job-data/
-              </span>
-              <input
-                type="text"
-                value={filename}
-                onChange={(e) => setFilename(e.target.value)}
-                placeholder="jobs-xxxxxxxx-total-x.csv"
-                disabled={loading}
-                className="flex-1 px-3 py-2 rounded-r-lg focus:outline-none"
-              />
-            </div>
+        <TabsContent value="upload">
+          <div className="bg-white rounded-lg shadow p-6 mb-6">
+            <h2 className="text-xl font-semibold mb-4">Upload jobs from Google Cloud Storage to the database</h2>
+
+            <form onSubmit={handleUploadSubmit}>
+              <div className="mb-4">
+                <label className="block text-sm font-medium mb-2">Enter CSV Filename</label>
+                <div className="flex items-center border border-gray-300 rounded-lg focus-within:ring-2 focus-within:ring-blue-500">
+                  <span className="px-3 py-2 bg-gray-100 text-gray-600 border-r border-gray-300 whitespace-nowrap rounded-l-lg">
+                    lv-storage/job-data/
+                  </span>
+                  <input
+                    type="text"
+                    value={filename}
+                    onChange={(e) => setFilename(e.target.value)}
+                    placeholder="jobs-xxxxxxxx-total-x.csv"
+                    disabled={uploadLoading}
+                    className="flex-1 px-3 py-2 rounded-r-lg focus:outline-none"
+                  />
+                </div>
+              </div>
+
+              <button
+                type="submit"
+                disabled={uploadLoading}
+                className="px-5 py-2.5 rounded-lg text-white font-medium transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+                style={{
+                  background: 'var(--gradient-primary)',
+                }}
+              >
+                {uploadLoading ? 'Processing...' : 'Upload Jobs'}
+              </button>
+            </form>
+
+            {uploadError && (
+              <div
+                className="mt-4 p-4 rounded-lg shadow-sm"
+                style={{
+                  backgroundColor: '#fef2f2',
+                  border: '1px solid #fecaca',
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-xl flex-shrink-0" style={{ color: '#ef4444' }}>
+                    ❌
+                  </span>
+                  <p className="font-medium" style={{ color: '#b91c1c' }}>
+                    {uploadError}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {uploadResponse && (
+              <div
+                className="mt-4 p-4 rounded-lg shadow-sm"
+                style={{
+                  backgroundColor: '#ecfdf5',
+                  border: '1px solid #a7f3d0',
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-xl flex-shrink-0" style={{ color: '#10b981' }}>
+                    ✓
+                  </span>
+                  <p className="font-medium" style={{ color: '#047857' }}>
+                    {uploadResponse.message}
+                  </p>
+                </div>
+              </div>
+            )}
           </div>
+        </TabsContent>
 
-          <button
-            type="submit"
-            disabled={loading}
-            className="px-5 py-2.5 rounded-lg text-white font-medium transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
-            style={{
-              background: 'var(--gradient-primary)',
-            }}
-          >
-            {loading ? 'Processing...' : 'Upload Jobs'}
-          </button>
-        </form>
+        <TabsContent value="embeddings">
+          <div className="bg-white rounded-lg shadow p-6 mb-6">
+            <h2 className="text-xl font-semibold mb-2">Job search embeddings</h2>
+            <p className="text-sm text-gray-600 mb-6">
+              Generate vector embeddings for jobs that are missing them. This runs in the background on the API server
+              and may take several minutes for large backlogs.
+            </p>
 
-        {error && (
-          <div 
-            className="mt-4 p-4 rounded-lg shadow-sm"
-            style={{
-              backgroundColor: '#fef2f2',
-              border: '1px solid #fecaca',
-            }}
-          >
-            <div className="flex items-start gap-3">
-              <span className="text-xl flex-shrink-0" style={{ color: '#ef4444' }}>❌</span>
-              <p className="font-medium" style={{ color: '#b91c1c' }}>{error}</p>
+            <div className="border border-gray-200 rounded-lg p-4 mb-6 bg-gray-50/80">
+              <div className="flex flex-wrap items-center justify-between gap-3 mb-3">
+                <h3 className="text-sm font-semibold text-gray-800">Embedding status</h3>
+                <button
+                  type="button"
+                  onClick={() => void loadStats()}
+                  disabled={statsLoading}
+                  className="text-sm font-medium text-blue-700 hover:text-blue-900 disabled:opacity-50"
+                >
+                  {statsLoading ? 'Refreshing…' : 'Refresh'}
+                </button>
+              </div>
+              {statsError && (
+                <p className="text-sm text-red-700 mb-2">{statsError}</p>
+              )}
+              {statsLoading && !stats ? (
+                <p className="text-sm text-gray-500">Loading stats…</p>
+              ) : stats ? (
+                <ul className="text-sm text-gray-700 space-y-1">
+                  <li>
+                    <span className="font-medium text-gray-900">Total jobs:</span> {stats.totalJobs}
+                  </li>
+                  <li>
+                    <span className="font-medium text-gray-900">Jobs with embeddings:</span>{' '}
+                    {stats.jobsWithEmbeddings}
+                  </li>
+                  <li>
+                    <span className="font-medium text-gray-900">Missing embeddings:</span>{' '}
+                    {stats.missingEmbeddings}
+                  </li>
+                </ul>
+              ) : null}
             </div>
-          </div>
-        )}
 
-        {response && (
-          <div 
-            className="mt-4 p-4 rounded-lg shadow-sm"
-            style={{
-              backgroundColor: '#ecfdf5',
-              border: '1px solid #a7f3d0',
-            }}
-          >
-            <div className="flex items-start gap-3">
-              <span className="text-xl flex-shrink-0" style={{ color: '#10b981' }}>✓</span>
-              <p className="font-medium" style={{ color: '#047857' }}>{response.message}</p>
-            </div>
+            {lastTriggeredAt && (
+              <p className="text-xs text-gray-500 mb-4">
+                Last triggered:{' '}
+                {new Date(lastTriggeredAt).toLocaleString(undefined, {
+                  dateStyle: 'medium',
+                  timeStyle: 'short',
+                })}
+                <span className="block mt-1">
+                  Generation runs asynchronously; counts update after jobs finish processing.
+                </span>
+              </p>
+            )}
+
+            <button
+              type="button"
+              disabled={embedLoading}
+              onClick={() => setEmbedConfirmOpen(true)}
+              className="px-5 py-2.5 rounded-lg text-white font-medium transition-all shadow-sm disabled:opacity-50 disabled:cursor-not-allowed"
+              style={{
+                background: 'var(--gradient-primary)',
+              }}
+            >
+              {embedLoading ? 'Starting…' : 'Trigger job embeddings'}
+            </button>
+
+            {embedError && (
+              <div
+                className="mt-4 p-4 rounded-lg shadow-sm"
+                style={{
+                  backgroundColor: '#fef2f2',
+                  border: '1px solid #fecaca',
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-xl flex-shrink-0" style={{ color: '#ef4444' }}>
+                    ❌
+                  </span>
+                  <p className="font-medium" style={{ color: '#b91c1c' }}>
+                    {embedError}
+                  </p>
+                </div>
+              </div>
+            )}
+
+            {embedResponse && (
+              <div
+                className="mt-4 p-4 rounded-lg shadow-sm"
+                style={{
+                  backgroundColor: '#ecfdf5',
+                  border: '1px solid #a7f3d0',
+                }}
+              >
+                <div className="flex items-start gap-3">
+                  <span className="text-xl flex-shrink-0" style={{ color: '#10b981' }}>
+                    ✓
+                  </span>
+                  <div>
+                    <p className="font-medium" style={{ color: '#047857' }}>
+                      {embedResponse.message}
+                    </p>
+                    <p className="text-sm mt-2" style={{ color: '#047857' }}>
+                      You can leave this page. Use Refresh above after a few minutes to verify counts.
+                    </p>
+                  </div>
+                </div>
+              </div>
+            )}
           </div>
-        )}
-      </div>
+        </TabsContent>
+      </Tabs>
+
+      <AlertDialog open={embedConfirmOpen} onOpenChange={setEmbedConfirmOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>Trigger job embeddings?</AlertDialogTitle>
+            <AlertDialogDescription>
+              This starts background embedding generation for all jobs that do not yet have a{' '}
+              <code className="text-xs bg-muted px-1 rounded">job_embedding</code>. You can safely close this tab; the
+              API will keep working. Only trigger again if a previous run failed or after new jobs were imported.
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <AlertDialogFooter>
+            <AlertDialogCancel>Cancel</AlertDialogCancel>
+            <AlertDialogAction
+              onClick={(e) => {
+                e.preventDefault();
+                void handleConfirmGenerateEmbeddings();
+              }}
+            >
+              Start embedding
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
     </div>
   );
 }

--- a/apps/lv-web/src/app/api/admin/job-embeddings/stats/route.ts
+++ b/apps/lv-web/src/app/api/admin/job-embeddings/stats/route.ts
@@ -1,0 +1,33 @@
+import type { AdminJobEmbeddingStats } from '@/types/admin';
+import { prisma } from '@repo/db';
+import { requireAdminAuth } from '@repo/lib';
+import { NextResponse } from 'next/server';
+
+export async function GET() {
+  const authError = await requireAdminAuth();
+  if (authError) {
+    return authError;
+  }
+
+  try {
+    const rows = await prisma.$queryRawUnsafe<[{ total: number; with_embeddings: number }]>(
+      `SELECT COUNT(*)::int AS total, COUNT(job_embedding)::int AS with_embeddings FROM "Job"`
+    );
+
+    const row = rows[0];
+    const totalJobs = row?.total ?? 0;
+    const jobsWithEmbeddings = row?.with_embeddings ?? 0;
+    const missingEmbeddings = Math.max(0, totalJobs - jobsWithEmbeddings);
+
+    const stats: AdminJobEmbeddingStats = {
+      totalJobs,
+      jobsWithEmbeddings,
+      missingEmbeddings,
+    };
+
+    return NextResponse.json(stats);
+  } catch (error) {
+    console.error('Error fetching job embedding stats:', error);
+    return NextResponse.json({ error: 'Internal server error' }, { status: 500 });
+  }
+}

--- a/apps/lv-web/src/app/dashboard/layout.tsx
+++ b/apps/lv-web/src/app/dashboard/layout.tsx
@@ -332,7 +332,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                     <SidebarMenuButton
                       onClick={() => handleMobileNavigation('/admin/jobs')}
                       isActive={pathname?.startsWith('/admin/jobs')}
-                      tooltip="Upload Jobs"
+                      tooltip="Job data"
                       style={
                         pathname?.startsWith('/admin/jobs')
                           ? { backgroundColor: 'var(--bg-hover)' }
@@ -350,7 +350,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                             pathname?.startsWith('/admin/jobs') ? 'text-gray-900' : 'text-gray-600'
                           }
                         >
-                          Upload Jobs
+                          Job data
                         </span>
                       </div>
                     </SidebarMenuButton>
@@ -426,7 +426,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
                   : pathname?.startsWith('/admin/users')
                     ? 'Admin'
                     : pathname?.startsWith('/admin/jobs')
-                      ? 'Upload Jobs'
+                      ? 'Job data'
                       : 'Dashboard'}
           </h2>
         </div>

--- a/apps/lv-web/src/lib/services/pyapi.ts
+++ b/apps/lv-web/src/lib/services/pyapi.ts
@@ -57,6 +57,29 @@ export async function uploadJobs(filename: string): Promise<{ message: string; s
   return data;
 }
 
+export async function generateJobEmbeddings(): Promise<{ message: string; status: number }> {
+  const response = await fetch(`${getBaseUrl()}/api/jobs/generate-embeddings`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({}),
+  });
+
+  const data = await response.json();
+
+  if (!response.ok) {
+    const detail = data.detail;
+    const detailStr =
+      typeof detail === 'string'
+        ? detail
+        : Array.isArray(detail)
+          ? detail.map((d: { msg?: string }) => d?.msg).filter(Boolean).join(', ')
+          : undefined;
+    throw new Error(data.message || detailStr || `Failed to start embedding generation: ${response.statusText}`);
+  }
+
+  return data;
+}
+
 interface PyAPIMatchJob {
   id: string;
   job_title: string;

--- a/apps/lv-web/src/types/admin.ts
+++ b/apps/lv-web/src/types/admin.ts
@@ -40,3 +40,12 @@ export interface LearningConnection {
   createdAt: string;
   messages: string[];
 }
+
+/**
+ * Stats returned by GET /api/admin/job-embeddings/stats
+ */
+export interface AdminJobEmbeddingStats {
+  totalJobs: number;
+  jobsWithEmbeddings: number;
+  missingEmbeddings: number;
+}


### PR DESCRIPTION
## Add functionality to generate job embeddings straight from the admin interface
- Tab based navigation on "Jobs" page

### How to test (given that you have the jobs already uploaded)
1. Connect to db:
`sudo docker exec -it $(docker ps -q --filter name=lv-db) psql -U postgres`
2. Remove job embeddings:
`UPDATE "Job" SET job_embedding=NULL;`
3. Verify that there are missing jobs
4. Regenerate jobs using the button
5. Verify jobs generated
- Test from terminal `SELECT job_embedding FROM "Job";`
- Refresh admin page UI to see "Jobs with embeddings: X" and "Jobs missing embeddings: 0"