### PR TITLE
fix(#181): interview UX + logout clears interview session

### DIFF
--- a/apps/lv-pyapi/agents/agent.py
+++ b/apps/lv-pyapi/agents/agent.py
@@ -210,6 +210,8 @@ async def my_agent(ctx: agents.JobContext):
             audio_input=room_io.AudioInputOptions(
                 noise_cancellation=noise_cancellation.NC(),
             ),
+            # Abandoned interviews: when the candidate disconnects, close and delete the room
+            # so the agent session does not linger as an open “same” interview.
             close_on_disconnect=True,
             delete_room_on_close=True,
         ),

--- a/apps/lv-web/src/app/dashboard/interview/components/InterviewStartScreen.tsx
+++ b/apps/lv-web/src/app/dashboard/interview/components/InterviewStartScreen.tsx
@@ -20,13 +20,13 @@ export function InterviewStartScreen({
   let durationText = 'This will take 10-15 minutes';
 
   if (allCompleted) {
-    title = 'Welcome back!';
-    subtitle = 'Want to update some information?';
-    buttonText = 'Resume Call';
-    durationText = 'Chat freely with the assistant';
+    title = 'Interview completed';
+    subtitle = 'You finished every section. Open a call only if you want to add or change something.';
+    buttonText = 'Start Call';
+    durationText = 'Optional follow-up with the assistant';
   } else if (partiallyCompleted) {
-    title = 'Welcome back to the interview!';
-    subtitle = `Press the button to continue your interview`;
+    title = 'Continue your interview?';
+    subtitle = `Your progress is saved (${totalTasks - completedTasksCount} sections left). Start the call only if you want to pick up where you left off.`;
     buttonText = 'Continue Call';
     durationText = `${totalTasks - completedTasksCount} sections remaining`;
   }
@@ -74,6 +74,10 @@ export function InterviewStartScreen({
           <p className="text-xs text-gray-500">{durationText}</p>
         </div>
       </div>
+      <p className="text-xs text-gray-400 text-center max-w-md px-6">
+        Finished sections are saved on your account. Signing out clears interview settings on this browser
+        only. Leaving a call ends that session—you can start a new one anytime.
+      </p>
     </div>
   );
 }

--- a/apps/lv-web/src/app/dashboard/layout.tsx
+++ b/apps/lv-web/src/app/dashboard/layout.tsx
@@ -28,6 +28,22 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 const OPPORTUNITIES_COUNT_STORAGE_KEY = 'opportunities-count';
 
+/**
+ * Clears interview UI state in this browser tab (voice/chat mode, mute, etc.).
+ * Account progress (completed interview sections in the database) is unchanged by sign-out.
+ */
+function clearInterviewSessionStorage() {
+  if (typeof window === 'undefined') return;
+  for (const key of [
+    'interview-voiceOnlyMode',
+    'interview-messages',
+    'interview-hasStarted',
+    'isAgentMuted',
+  ]) {
+    sessionStorage.removeItem(key);
+  }
+}
+
 function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   const { toggleSidebar, open } = useSidebar();
   const router = useRouter();
@@ -63,6 +79,7 @@ function DashboardLayoutContent({ children }: { children: React.ReactNode }) {
   const handleSignOut = () => {
     if (typeof window !== 'undefined') {
       sessionStorage.removeItem(OPPORTUNITIES_COUNT_STORAGE_KEY);
+      clearInterviewSessionStorage();
     }
     signOut({ callbackUrl: '/login' });
   };


### PR DESCRIPTION
Addresses issue#181. Minimal change (last sprint). Improves interview clarity after login/logout: 
- clearer completed vs in-progress copy
- a short note on what’s saved where
- clearing interview-related browser state on sign-out
- does not reset saved task progress in the DB. 

